### PR TITLE
Enhance MCP server testing with RunCmdOptions and in-memory transport

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,9 +4,7 @@
 *.dll
 *.so
 *.dylib
-
-# Test binary, built with `go test -c`
-*.test
+/tag-manager
 
 # Output of the go coverage tool, specifically when used with LiteIDE
 *.out
@@ -44,6 +42,5 @@ test-vault/
 testdata/
 
 # Build artifacts
-tag-manager
 dist/
 build/

--- a/README.md
+++ b/README.md
@@ -73,6 +73,11 @@ DRY RUN MODE - No files will be modified
 Modified files: 6
 ```
 
+Claude MCP Server
+```bash
+claude mcp add -s project tag-manager -- tag-manager -mcp
+```
+
 ## CLI Usage Guide
 
 ### 📋 Command Reference
@@ -424,30 +429,25 @@ tag-manager list --root="../../../etc"
 
 ### Setup for Claude Code
 
-1. **Start the MCP server:**
+**Start the MCP server:**
 ```bash
-tag-manager -mcp
-# Server starts on stdio, waiting for Claude Code connection
+claude mcp add -s project tag-manager -- tag-manager -mcp
 ```
 
-2. **Configure Claude Code** (`claude_desktop_config.json`):
+**Configure Claude Code** (`.mcp.json`):
 ```json
 {
   "mcpServers": {
-    "obsidian-tag-manager": {
+    "tag-manager": {
+      "type": "stdio",
       "command": "tag-manager",
-      "args": ["-mcp"],
-      "env": {
-        "OBSIDIAN_VAULT_PATH": "/vault"
-      }
+      "args": [
+        "-mcp",
+      ],
+      "env": {}
     }
   }
 }
-```
-
-3. **Custom configuration for MCP:**
-```bash
-tag-manager -mcp --config="/path/to/vault-specific-config.yaml"
 ```
 
 ### Available MCP Tools

--- a/cli.go
+++ b/cli.go
@@ -1,0 +1,461 @@
+package tagmanager
+
+import (
+	"context"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+// RunCmdOptions contains options for customizing RunCmd behavior
+type RunCmdOptions struct {
+	// MCPTransport allows providing a custom transport for MCP server (used for testing)
+	MCPTransport *mcp.InMemoryTransport
+}
+
+func RunCmd(args []string) error {
+	return RunCmdWithOptions(args, nil)
+}
+
+func RunCmdWithOptions(args []string, options *RunCmdOptions) error {
+	if len(args) < 1 {
+		return ShowHelp()
+	}
+
+	fs := flag.NewFlagSet(args[0], flag.ContinueOnError)
+
+	var (
+		help       = fs.Bool("h", false, "Show help")
+		mcpOption  = fs.Bool("mcp", false, "Run as MCP server")
+		verbose    = fs.Bool("v", false, "Verbose output")
+		dryRun     = fs.Bool("dry-run", false, "Show what would be changed without making changes")
+		configFile = fs.String("config", "", "Path to configuration file")
+	)
+
+	if len(args) > 1 {
+		if err := fs.Parse(args[1:]); err != nil {
+			return err
+		}
+	}
+
+	if *help {
+		return ShowHelp()
+	}
+
+	if *mcpOption {
+		var transport *mcp.InMemoryTransport
+		if options != nil && options.MCPTransport != nil {
+			transport = options.MCPTransport
+		}
+		return RunMCPServer(*configFile, transport)
+	}
+
+	remaining := fs.Args()
+	if len(remaining) == 0 {
+		return ShowHelp()
+	}
+
+	config, err := LoadConfig(*configFile)
+	if err != nil {
+		return fmt.Errorf("failed to load config: %w", err)
+	}
+
+	ctx := context.Background()
+	manager, err := NewDefaultTagManager(config)
+	if err != nil {
+		return fmt.Errorf("failed to create tag manager: %w", err)
+	}
+
+	switch remaining[0] {
+	case "find":
+		return findFilesCommand(ctx, manager, remaining[1:], *verbose)
+	case "info":
+		return getTagInfoCommand(ctx, manager, remaining[1:], *verbose)
+	case "list":
+		return listTagsCommand(ctx, manager, remaining[1:], *verbose)
+	case "replace":
+		return replaceTagCommand(ctx, manager, remaining[1:], *dryRun, *verbose)
+	case "untagged":
+		return untaggedFilesCommand(ctx, manager, remaining[1:], *verbose)
+	case "validate":
+		return validateTagsCommand(ctx, manager, remaining[1:], *verbose)
+	case "file-tags":
+		return getFileTagsCommand(ctx, manager, remaining[1:], *verbose)
+	default:
+		return fmt.Errorf("unknown command: %s", remaining[0])
+	}
+}
+
+func ShowHelp() error {
+	help := `Obsidian Tag Manager - Manage tags in Obsidian vaults
+
+Usage:
+  tag-manager [OPTIONS] COMMAND [ARGS...]
+  tag-manager -mcp              Run as MCP server
+
+Options:
+  -h, --help           Show this help message
+  -v, --verbose        Enable verbose output
+  --dry-run            Preview changes without modifying files
+  --config FILE        Path to configuration file
+  -mcp                 Run as MCP server
+
+Commands:
+  find         Find files containing specific tags
+  info         Get detailed information about tags
+  list         List all tags with usage statistics
+  replace      Replace/rename tags across files
+  untagged     Find files without any tags
+  validate     Validate tag syntax and suggest fixes
+  file-tags    Get tags for specific files
+
+Examples:
+  tag-manager find --tags="#golang,#python" --root="/path/to/vault"
+  tag-manager list --root="/path/to/vault" --min-count=2
+  tag-manager replace --old="#old-tag" --new="#new-tag" --root="/path/to/vault" --dry-run
+  tag-manager untagged --root="/path/to/vault"
+  tag-manager validate --tags="#test,#invalid-tag!"
+  tag-manager file-tags --files="/path/file1.md,/path/file2.md"
+  tag-manager -mcp --config="/path/to/config.yaml"
+
+For more information, visit: https://github.com/thrawn01/tag-manager
+`
+	fmt.Print(help)
+	return nil
+}
+
+func findFilesCommand(ctx context.Context, manager TagManager, args []string, verbose bool) error {
+	fs := flag.NewFlagSet("find", flag.ContinueOnError)
+
+	cwd, err := os.Getwd()
+	if err != nil {
+		return fmt.Errorf("failed to get current directory: %w", err)
+	}
+
+	tags := fs.String("tags", "", "Comma-separated list of tags to search for")
+	root := fs.String("root", cwd, "Root directory to search")
+	maxResults := fs.Int("max-results", 100, "Maximum files per tag")
+	jsonOutput := fs.Bool("json", false, "Output as JSON")
+
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+
+	if *tags == "" {
+		return fmt.Errorf("--tags is required")
+	}
+
+	tagList := strings.Split(*tags, ",")
+	for i := range tagList {
+		tagList[i] = strings.TrimSpace(tagList[i])
+	}
+
+	results, err := manager.FindFilesByTags(ctx, tagList, *root)
+	if err != nil {
+		return err
+	}
+
+	for tag, files := range results {
+		if len(files) > *maxResults {
+			files = files[:*maxResults]
+			results[tag] = files
+		}
+	}
+
+	if *jsonOutput {
+		return json.NewEncoder(os.Stdout).Encode(results)
+	}
+
+	for tag, files := range results {
+		fmt.Printf("\n#%s (%d files):\n", tag, len(files))
+		for _, file := range files {
+			fmt.Printf("  %s\n", file)
+		}
+	}
+
+	return nil
+}
+
+func getTagInfoCommand(ctx context.Context, manager TagManager, args []string, verbose bool) error {
+	fs := flag.NewFlagSet("info", flag.ContinueOnError)
+
+	cwd, err := os.Getwd()
+	if err != nil {
+		return fmt.Errorf("failed to get current directory: %w", err)
+	}
+
+	tags := fs.String("tags", "", "Comma-separated list of tags")
+	root := fs.String("root", cwd, "Root directory to search")
+	jsonOutput := fs.Bool("json", false, "Output as JSON")
+
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+
+	if *tags == "" {
+		return fmt.Errorf("--tags is required")
+	}
+
+	tagList := strings.Split(*tags, ",")
+	for i := range tagList {
+		tagList[i] = strings.TrimSpace(tagList[i])
+	}
+
+	infos, err := manager.GetTagsInfo(ctx, tagList, *root)
+	if err != nil {
+		return err
+	}
+
+	if *jsonOutput {
+		return json.NewEncoder(os.Stdout).Encode(infos)
+	}
+
+	for _, info := range infos {
+		fmt.Printf("\n#%s:\n", info.Name)
+		fmt.Printf("  Count: %d\n", info.Count)
+		if verbose {
+			fmt.Printf("  Files:\n")
+			for _, file := range info.Files {
+				fmt.Printf("    %s\n", file)
+			}
+		}
+	}
+
+	return nil
+}
+
+func listTagsCommand(ctx context.Context, manager TagManager, args []string, verbose bool) error {
+	fs := flag.NewFlagSet("list", flag.ContinueOnError)
+
+	cwd, err := os.Getwd()
+	if err != nil {
+		return fmt.Errorf("failed to get current directory: %w", err)
+	}
+
+	root := fs.String("root", cwd, "Root directory to search")
+	minCount := fs.Int("min-count", 1, "Minimum usage count")
+	pattern := fs.String("pattern", "", "Optional regex pattern to filter tags")
+	jsonOutput := fs.Bool("json", false, "Output as JSON")
+
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+
+	tags, err := manager.ListAllTags(ctx, *root, *minCount)
+	if err != nil {
+		return err
+	}
+
+	if *pattern != "" {
+		// Filter tags by pattern
+		var filtered []TagInfo
+		for _, tag := range tags {
+			if strings.Contains(tag.Name, *pattern) {
+				filtered = append(filtered, tag)
+			}
+		}
+		tags = filtered
+	}
+
+	if *jsonOutput {
+		return json.NewEncoder(os.Stdout).Encode(tags)
+	}
+
+	fmt.Printf("\nFound %d tags:\n", len(tags))
+	for _, tag := range tags {
+		fmt.Printf("  #%-30s %d files\n", tag.Name, tag.Count)
+	}
+
+	return nil
+}
+
+func replaceTagCommand(ctx context.Context, manager TagManager, args []string, globalDryRun bool, verbose bool) error {
+	fs := flag.NewFlagSet("replace", flag.ContinueOnError)
+
+	cwd, err := os.Getwd()
+	if err != nil {
+		return fmt.Errorf("failed to get current directory: %w", err)
+	}
+
+	replacements := fs.String("replacements", "", "Comma-separated replacements (old1:new1,old2:new2)")
+	old := fs.String("old", "", "Old tag to replace")
+	new := fs.String("new", "", "New tag name")
+	root := fs.String("root", cwd, "Root directory to search")
+	jsonOutput := fs.Bool("json", false, "Output as JSON")
+	localDryRun := fs.Bool("dry-run", false, "Show what would be changed without making changes")
+
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+
+	var replaceList []TagReplacement
+
+	if *replacements != "" {
+		pairs := strings.Split(*replacements, ",")
+		for _, pair := range pairs {
+			parts := strings.Split(pair, ":")
+			if len(parts) != 2 {
+				return fmt.Errorf("invalid replacement format: %s", pair)
+			}
+			replaceList = append(replaceList, TagReplacement{
+				OldTag: strings.TrimSpace(parts[0]),
+				NewTag: strings.TrimSpace(parts[1]),
+			})
+		}
+	} else if *old != "" && *new != "" {
+		replaceList = append(replaceList, TagReplacement{
+			OldTag: *old,
+			NewTag: *new,
+		})
+	} else {
+		return fmt.Errorf("either --replacements or both --old and --new are required")
+	}
+
+	dryRun := globalDryRun || *localDryRun
+	if dryRun {
+		fmt.Println("DRY RUN MODE - No files will be modified")
+	}
+
+	result, err := manager.ReplaceTagsBatch(ctx, replaceList, *root, dryRun)
+	if err != nil {
+		return err
+	}
+
+	if *jsonOutput {
+		return json.NewEncoder(os.Stdout).Encode(result)
+	}
+
+	fmt.Printf("\nModified files: %d\n", len(result.ModifiedFiles))
+	if verbose {
+		for _, file := range result.ModifiedFiles {
+			fmt.Printf("  %s\n", file)
+		}
+	}
+
+	if len(result.FailedFiles) > 0 {
+		fmt.Printf("\nFailed files: %d\n", len(result.FailedFiles))
+		for i, file := range result.FailedFiles {
+			fmt.Printf("  %s: %s\n", file, result.Errors[i])
+		}
+	}
+
+	return nil
+}
+
+func untaggedFilesCommand(ctx context.Context, manager TagManager, args []string, verbose bool) error {
+	fs := flag.NewFlagSet("untagged", flag.ContinueOnError)
+
+	cwd, err := os.Getwd()
+	if err != nil {
+		return fmt.Errorf("failed to get current directory: %w", err)
+	}
+
+	root := fs.String("root", cwd, "Root directory to search")
+	jsonOutput := fs.Bool("json", false, "Output as JSON")
+
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+
+	files, err := manager.GetUntaggedFiles(ctx, *root)
+	if err != nil {
+		return err
+	}
+
+	if *jsonOutput {
+		return json.NewEncoder(os.Stdout).Encode(files)
+	}
+
+	fmt.Printf("\nFound %d untagged files:\n", len(files))
+	for _, file := range files {
+		fmt.Printf("  %s\n", file.Path)
+	}
+
+	return nil
+}
+
+func validateTagsCommand(ctx context.Context, manager TagManager, args []string, verbose bool) error {
+	fs := flag.NewFlagSet("validate", flag.ContinueOnError)
+	tags := fs.String("tags", "", "Comma-separated list of tags to validate")
+	jsonOutput := fs.Bool("json", false, "Output as JSON")
+
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+
+	if *tags == "" {
+		return fmt.Errorf("--tags is required")
+	}
+
+	tagList := strings.Split(*tags, ",")
+	for i := range tagList {
+		tagList[i] = strings.TrimSpace(tagList[i])
+	}
+
+	results := manager.ValidateTags(ctx, tagList)
+
+	if *jsonOutput {
+		return json.NewEncoder(os.Stdout).Encode(results)
+	}
+
+	for tag, result := range results {
+		if result.IsValid {
+			fmt.Printf("\n✓ %s: VALID\n", tag)
+		} else {
+			fmt.Printf("\n✗ %s: INVALID\n", tag)
+			for _, issue := range result.Issues {
+				fmt.Printf("  Issue: %s\n", issue)
+			}
+			for _, suggestion := range result.Suggestions {
+				fmt.Printf("  → %s\n", suggestion)
+			}
+		}
+	}
+
+	return nil
+}
+
+func getFileTagsCommand(ctx context.Context, manager TagManager, args []string, verbose bool) error {
+	fs := flag.NewFlagSet("file-tags", flag.ContinueOnError)
+	files := fs.String("files", "", "Comma-separated list of file paths")
+	jsonOutput := fs.Bool("json", false, "Output as JSON")
+
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+
+	if *files == "" {
+		return fmt.Errorf("--files is required")
+	}
+
+	fileList := strings.Split(*files, ",")
+	for i := range fileList {
+		fileList[i] = strings.TrimSpace(fileList[i])
+	}
+
+	fileTags, err := manager.GetFilesTags(ctx, fileList)
+	if err != nil {
+		return err
+	}
+
+	if *jsonOutput {
+		return json.NewEncoder(os.Stdout).Encode(fileTags)
+	}
+
+	for _, file := range fileTags {
+		fmt.Printf("\n%s:\n", file.Path)
+		if len(file.Tags) == 0 {
+			fmt.Printf("  (no tags)\n")
+		} else {
+			for _, tag := range file.Tags {
+				fmt.Printf("  #%s\n", tag)
+			}
+		}
+	}
+
+	return nil
+}

--- a/cli_test.go
+++ b/cli_test.go
@@ -1,0 +1,187 @@
+package tagmanager_test
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+	tagmanager "github.com/thrawn01/tag-manager"
+)
+
+func TestCLIIntegration(t *testing.T) {
+	tempDir := t.TempDir()
+
+	testFiles := map[string]string{
+		"test1.md": "# Test 1\n#golang #programming",
+		"test2.md": "# Test 2\n#python #data-science",
+		"test3.md": "# Test 3\nNo tags here",
+	}
+
+	for path, content := range testFiles {
+		fullPath := filepath.Join(tempDir, path)
+		if err := os.WriteFile(fullPath, []byte(content), 0644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	tests := []struct {
+		name        string
+		args        []string
+		expectError bool
+	}{
+		{
+			name: "Help",
+			args: []string{"tag-manager", "-h"},
+		},
+		{
+			name: "FindCommand",
+			args: []string{"tag-manager", "find", "--tags=golang", "--root=" + tempDir, "--json"},
+		},
+		{
+			name: "ListCommand",
+			args: []string{"tag-manager", "list", "--root=" + tempDir, "--json"},
+		},
+		{
+			name: "UntaggedCommand",
+			args: []string{"tag-manager", "untagged", "--root=" + tempDir, "--json"},
+		},
+		{
+			name: "ValidateCommand",
+			args: []string{"tag-manager", "validate", "--tags=valid-tag,invalid!", "--json"},
+		},
+		{
+			name: "FileTagsCommand",
+			args: []string{"tag-manager", "file-tags", "--files=" + filepath.Join(tempDir, "test1.md"), "--json"},
+		},
+		{
+			name: "ReplaceCommandDryRun",
+			args: []string{"tag-manager", "replace", "--old=golang", "--new=go", "--root=" + tempDir, "--dry-run", "--json"},
+		},
+		{
+			name:        "InvalidCommand",
+			args:        []string{"tag-manager", "invalid"},
+			expectError: true,
+		},
+		{
+			name:        "MissingRequiredArgs",
+			args:        []string{"tag-manager", "find"},
+			expectError: true,
+		},
+		{
+			name: "InvalidPath",
+			args: []string{"tag-manager", "find", "--tags=test", "--root=/nonexistent", "--json"},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			err := tagmanager.RunCmd(test.args)
+			if test.expectError {
+				if err == nil {
+					t.Error("Expected error but got none")
+				}
+			} else {
+				if err != nil {
+					t.Errorf("Unexpected error: %v", err)
+				}
+			}
+		})
+	}
+}
+
+func TestCLIGlobalFlags(t *testing.T) {
+	tempDir := t.TempDir()
+
+	testFile := filepath.Join(tempDir, "test.md")
+	if err := os.WriteFile(testFile, []byte("# Test\n#golang"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	tests := []struct {
+		name string
+		args []string
+	}{
+		{
+			name: "VerboseFlag",
+			args: []string{"tag-manager", "-v", "list", "--root=" + tempDir, "--json"},
+		},
+		{
+			name: "DryRunFlag",
+			args: []string{"tag-manager", "--dry-run", "replace", "--old=golang", "--new=go", "--root=" + tempDir, "--json"},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			err := tagmanager.RunCmd(test.args)
+			if err != nil {
+				t.Errorf("Unexpected error with global flags: %v", err)
+			}
+		})
+	}
+}
+
+func TestMCPServerCapabilities(t *testing.T) {
+	t.Run("MCPServerToolDiscovery", func(t *testing.T) {
+		ctx := context.Background()
+
+		// Create in-memory transports for testing
+		clientTransport, serverTransport := mcp.NewInMemoryTransports()
+
+		// Start our MCP server using RunCmdWithOptions in a goroutine
+		serverDone := make(chan error, 1)
+		go func() {
+			options := &tagmanager.RunCmdOptions{
+				MCPTransport: serverTransport,
+			}
+			serverDone <- tagmanager.RunCmdWithOptions([]string{"tag-manager", "-mcp"}, options)
+		}()
+
+		// Create MCP client
+		client := mcp.NewClient(&mcp.Implementation{Name: "test-client", Version: "v1.0.0"}, nil)
+		session, err := client.Connect(ctx, clientTransport, nil)
+		if err != nil {
+			t.Fatalf("Failed to connect MCP client: %v", err)
+		}
+		defer func() {
+			_ = session.Close()
+		}()
+
+		// Test that we can ping the server
+		err = session.Ping(ctx, nil)
+		if err != nil {
+			t.Fatalf("Failed to ping MCP server: %v", err)
+		}
+
+		// List available tools from the server
+		tools, err := session.ListTools(ctx, &mcp.ListToolsParams{})
+		if err != nil {
+			t.Fatalf("Failed to list tools: %v", err)
+		}
+
+		// Verify that our list_all_tags tool is available
+		found := false
+		for _, tool := range tools.Tools {
+			if tool.Name == "list_all_tags" {
+				found = true
+				if tool.Description != "List all tags with usage statistics" {
+					t.Errorf("Expected tool description 'List all tags with usage statistics', got '%s'", tool.Description)
+				}
+				break
+			}
+		}
+
+		if !found {
+			t.Error("Expected 'list_all_tags' tool to be available, but it was not found")
+		}
+
+		// Verify we have at least one tool
+		if len(tools.Tools) == 0 {
+			t.Error("Expected at least one tool to be available")
+		}
+
+		t.Logf("Successfully discovered %d tools from MCP server", len(tools.Tools))
+	})
+}

--- a/cmd/tag-manager/main.go
+++ b/cmd/tag-manager/main.go
@@ -1,0 +1,15 @@
+package main
+
+import (
+	"fmt"
+	"os"
+
+	tagmanager "github.com/thrawn01/tag-manager"
+)
+
+func main() {
+	if err := tagmanager.RunCmd(os.Args); err != nil {
+		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		os.Exit(1)
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,12 @@ module github.com/thrawn01/tag-manager
 
 go 1.24
 
-require gopkg.in/yaml.v3 v3.0.1
+require (
+	github.com/modelcontextprotocol/go-sdk v0.3.1
+	gopkg.in/yaml.v3 v3.0.1
+)
+
+require (
+	github.com/google/jsonschema-go v0.2.1-0.20250825175020-748c325cec76 // indirect
+	github.com/yosida95/uritemplate/v3 v3.0.2 // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,13 @@
+github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
+github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=
+github.com/google/jsonschema-go v0.2.1-0.20250825175020-748c325cec76 h1:mBlBwtDebdDYr+zdop8N62a44g+Nbv7o2KjWyS1deR4=
+github.com/google/jsonschema-go v0.2.1-0.20250825175020-748c325cec76/go.mod h1:r5quNTdLOYEz95Ru18zA0ydNbBuYoo9tgaYcxEYhJVE=
+github.com/modelcontextprotocol/go-sdk v0.3.1 h1:0z04yIPlSwTluuelCBaL+wUag4YeflIU2Fr4Icb7M+o=
+github.com/modelcontextprotocol/go-sdk v0.3.1/go.mod h1:whv0wHnsTphwq7CTiKYHkLtwLC06WMoY2KpO+RB9yXQ=
+github.com/yosida95/uritemplate/v3 v3.0.2 h1:Ed3Oyj9yrmi9087+NczuL5BwkIc4wvTb5zIM+UJPGz4=
+github.com/yosida95/uritemplate/v3 v3.0.2/go.mod h1:ILOh0sOhIJR3+L/8afwt/kE++YT040gmv5BQTMR2HP4=
+golang.org/x/tools v0.34.0 h1:qIpSLOxeCYGg9TrcJokLBG4KFA6d795g0xkBkiESGlo=
+golang.org/x/tools v0.34.0/go.mod h1:pAP9OwEaY1CAW3HOmg3hLZC5Z0CCmzjAF2UQMSqNARg=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=

--- a/mcp.go
+++ b/mcp.go
@@ -1,0 +1,78 @@
+package tagmanager
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/signal"
+	"syscall"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+type ListTagsParams struct {
+	Root     string `json:"root"`
+	MinCount int    `json:"min_count"`
+}
+
+func ListAllTagsTool(ctx context.Context, req *mcp.CallToolRequest, args ListTagsParams, manager TagManager) (*mcp.CallToolResult, any, error) {
+	tags, err := manager.ListAllTags(ctx, args.Root, args.MinCount)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to list tags: %w", err)
+	}
+
+	return &mcp.CallToolResult{
+		Content: []mcp.Content{
+			&mcp.TextContent{Text: fmt.Sprintf("Found %d tags", len(tags))},
+		},
+	}, tags, nil
+}
+
+// RunMCPServer starts the MCP server implementation using the official Go SDK
+// If transport is nil, it will use stdio transport
+func RunMCPServer(configPath string, transport *mcp.InMemoryTransport) error {
+	config, err := LoadConfig(configPath)
+	if err != nil {
+		return fmt.Errorf("failed to load config: %w", err)
+	}
+
+	manager, err := NewDefaultTagManager(config)
+	if err != nil {
+		return fmt.Errorf("failed to create tag manager: %w", err)
+	}
+
+	// Create MCP server
+	server := mcp.NewServer(&mcp.Implementation{
+		Name:    "tag-manager",
+		Version: "1.0.0",
+	}, nil)
+
+	// Register tools with proper handlers
+	mcp.AddTool(server, &mcp.Tool{
+		Name:        "list_all_tags",
+		Description: "List all tags with usage statistics",
+	}, func(ctx context.Context, req *mcp.CallToolRequest, args ListTagsParams) (*mcp.CallToolResult, any, error) {
+		return ListAllTagsTool(ctx, req, args, manager)
+	})
+
+	// Set up context with cancellation
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// Handle shutdown signals
+	sigChan := make(chan os.Signal, 1)
+	signal.Notify(sigChan, os.Interrupt, syscall.SIGTERM)
+	go func() {
+		<-sigChan
+		cancel()
+	}()
+
+	// Use provided transport or default to stdio
+	if transport != nil {
+		// Use the provided InMemoryTransport for testing
+		return server.Run(ctx, transport)
+	} else {
+		// Use stdio transport for production
+		return server.Run(ctx, &mcp.StdioTransport{})
+	}
+}


### PR DESCRIPTION
### Purpose
This change enhances the MCP server testing infrastructure by implementing proper integration testing that uses the actual CLI entry point with customizable transport options for testing.

### Implementation
- **Added RunCmdOptions struct**: Created a configuration struct that allows passing custom MCP transport for testing while maintaining backward compatibility
- **Enhanced RunCmd function**: Split into `RunCmd()` and `RunCmdWithOptions()` where the former maintains the existing API and the latter accepts the new options struct
- **Updated RunMCPServer**: Modified to accept and use custom transport (InMemoryTransport for testing, StdioTransport for production)
- **Improved MCP server test**: Replaced basic flag parsing test with comprehensive integration test that:
  - Uses `RunCmdWithOptions()` to start the actual MCP server via CLI
  - Creates in-memory client-server communication using `mcp.NewInMemoryTransports()`
  - Tests server capability discovery through MCP protocol
  - Verifies that tools are properly exposed and discoverable
  - Validates MCP protocol compliance (handshake, ping, tool listing)

This approach provides much better test coverage by testing the full CLI-to-MCP-server integration path rather than just flag parsing, ensuring the MCP functionality works correctly in realistic scenarios.